### PR TITLE
handle context

### DIFF
--- a/gdb_plus/gdb_plus.py
+++ b/gdb_plus/gdb_plus.py
@@ -2934,7 +2934,8 @@ class Debugger:
                         self.__set_stop("We hit a breakpoint while interrupting the process. Handle it!")
                             
                 ## Non puoi eseguire azioni dentro ad un handler degli eventi quindi lancio in un thread a parte
-                context.Thread(target=split, args = (inferior,), name=f"[{self.pid}] split_fork").start()
+                with context.local(**self.context):
+                    context.Thread(target=split, args = (inferior,), name=f"[{self.pid}] split_fork").start()
 
             self.fork_handler = fork_handler
             self.gdb.events.new_inferior.connect(self.fork_handler)

--- a/gdb_plus/gdb_plus.py
+++ b/gdb_plus/gdb_plus.py
@@ -56,7 +56,7 @@ class Debugger:
         self.ptrace_backups = {}
 
         self.pid = None
-        self.context = context.copy()
+        self.context_params = context.copy()
 
         self.gdb = None
         self.libdebug = None
@@ -255,7 +255,7 @@ class Debugger:
         Actions that the debugger performs every time the process is interrupted
         Handle temporary breakpoints and callbacks
         """
-        with context.local(**self.context):
+        with context.local(**self.context_params):
 
             # Current inferior will change to the inferior who stopped last
             ip = self.instruction_pointer
@@ -353,7 +353,7 @@ class Debugger:
         Actions that the debugger performs every time the process is interrupted
         Handle temporary breakpoints and callbacks
         """
-        with context.local(**self.context):
+        with context.local(**self.context_params):
 
             # If we detach there will be a step to shutdown waitpid, but libdebug will have detached before we can execute the handler, so let's just skip it.
             if self.detached:
@@ -2934,7 +2934,7 @@ class Debugger:
                         self.__set_stop("We hit a breakpoint while interrupting the process. Handle it!")
                             
                 ## Non puoi eseguire azioni dentro ad un handler degli eventi quindi lancio in un thread a parte
-                with context.local(**self.context):
+                with context.local(**self.context_params):
                     context.Thread(target=split, args = (inferior,), name=f"[{self.pid}] split_fork").start()
 
             self.fork_handler = fork_handler


### PR DESCRIPTION
The callbacks on gdb.events can not access our context.

`539f77f (Remove restore_arch, 2023-12-29)` tried to solve the problem by saving all the parameters of context and then using `context.local(**self.context_params)` in these callbacks to work properly. It missed the callback for new_inferior though.

An alternative would be to save a pointer to the context variable and have the callbacks be lamda functions that call `self.context.Thread`. The difference would be that any change to the context would affect all the debuggers running in the script and I feel safer with just a backup made when we create the object.