### PR TITLE
Expand ELF class

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,13 +266,6 @@ canary = dbg.canary
 **Note**  
 While you can access the registers only when the process is at a stop, remember that you can read and write on the memory at any time
 
-Pwntools let you access the address where each library is loaded with `p.libs()[<path_to_library>]`
-We have two wrapper for the main ones:
-* `dbg.elf_address`
-* `dbg.libc_address`
-
-These are similar to dbg.elf.address and dbg.libc.address, but when set by an exploit, if the address is already known to gdb, will warn you if you got the wrong leak.
-
 We can also use capstone to know what is the next instruction that will be executed
 ```py
 print(dbg.next_inst.toString()) # "mov rax, r12"

--- a/README.md
+++ b/README.md
@@ -425,3 +425,4 @@ If your binary requires system libraries, look at the (instructions)[https://doc
 * hide internal breakpoints also from gdb
 * implement strace
 * allow access to float registers or aliases
+* improve access to program libraries

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 GDB+ 7.1.1
-* Check libc_address and elf_address correctly aligned.
+* Check libc.address and elf.address correctly aligned.
 * allow Debugger(silent=True) to hide pwntools default logs
+* Execute from_entry only if inside the loader
 
 GDB+ 7.1.0 QEMU support
 * Find libc used by process under QEMU

--- a/gdb_plus/gdb_plus.py
+++ b/gdb_plus/gdb_plus.py
@@ -3199,23 +3199,17 @@ class Debugger:
     def libc(self, elf_libc: ELF):
         self._libc = elf_libc
 
+    # NOTE: Here for backward compatibility with 7.0 
     @property
     def base_libc(self):
         if self.libc is None:
             log.error("I don't see a libc ! Set dbg.libc = ELF(<path_to_libc>)")
         return self.libc.address
-
     @base_libc.setter
     def base_libc(self, address):
-        if self.debugging and address != self.base_libc:
-            log.warn("The base address of the libc is not the one expected! Expected: %s. Received: %s", hex(self.base_libc), hex(address))
-
-        if address % 0x1000:
-            log.warn("The address %s is not a multiple of the page size 0x1000. Are you sure this is your base address ?", hex(address))
-
+        if self.libc is None:
+            log.error("I don't see a libc ! Set dbg.libc = ELF(<path_to_libc>)")
         self.libc.address = address
-        self._base_libc = address
-
     libc_address = base_libc
 
     # If we don't have the binary we may consider iterating over the libraries to find a name that doesn't start with lib or ld- [05/02/25]
@@ -3225,24 +3219,16 @@ class Debugger:
             self._set_range(self._exe)
 
         return self._exe 
-    
+
     elf = exe
 
+    # NOTE: Here for backward compatibility with 7.0 
     @property
     def base_elf(self):
-        return self._exe.address
-
+        return self.exe.address
     @base_elf.setter
     def base_elf(self, address):
-        if self.debugging and address != self.base_elf:
-            log.warn("The base address of the binary is not the one expected! Expected: %s. Received: %s", hex(self.base_elf), hex(address))
-
-        if address % 0x1000:
-            log.warn("The address %s is not a multiple of the page size 0x1000. Are you sure this is your base address ?", hex(address))
-             
         self.exe.address = address
-        self._base_elf = address
-
     elf_address = base_elf
     exe_address = base_elf
 

--- a/gdb_plus/gdb_plus.py
+++ b/gdb_plus/gdb_plus.py
@@ -3113,10 +3113,7 @@ class Debugger:
                 offset += 8
             if file.data[offset:offset+0x8] != self.read(address+offset, 8):
                 log.warn_once("QEMU messed up the elf base. Trying to find correct address...")
-                limit = 2 if (self._gef or self._pwndbg) else 0
-                while i > limit:
-                    i -= 1
-                    address = int(data.splitlines()[i].strip().split()[0], 16)
+                for address in self.maps:
                     if file.data[offset:offset+0x8] == self.read(address+offset, 8):
                         log.success(f"Found address {hex(address)}!")
                         break

--- a/gdb_plus/gdb_plus.py
+++ b/gdb_plus/gdb_plus.py
@@ -2719,6 +2719,7 @@ class Debugger:
         return maps
 
     # I copied it from pwntools to have access to it even if I attach directly to a pid
+    @property
     def libs(self):
         """libs() -> dict
         Return a dictionary mapping the path of each shared library loaded

--- a/gdb_plus/gdb_plus.py
+++ b/gdb_plus/gdb_plus.py
@@ -2721,6 +2721,7 @@ class Debugger:
         return maps
 
     # I copied it from pwntools to have access to it even if I attach directly to a pid
+    # TODO consider making a way to access all the libraries in the form of a dict of EXE [05/02/25]
     @property
     def libs(self):
         """libs() -> dict
@@ -2743,15 +2744,18 @@ class Debugger:
                 break
             path = os.path.realpath(path)
             if path not in maps:
-                maps[path]=0
+                maps[path]= []
 
         for lib in maps:
             path = os.path.realpath(lib)
             for line in maps_raw.splitlines():
                 if line.endswith(path):
-                    address = line.split('-')[0]
-                    maps[lib] = int(address, 16)
-                    break
+                    if len(maps[lib]) == 0:
+                        address = line.split('-')[0]
+                        maps[lib].append(int(address, 16))
+                    address = line.split()[0].split('-')[-1]
+                    maps[lib].append(int(address, 16))
+            maps[lib] = [maps[lib][0], maps[lib][-1]] # Keep only start and end of the file in memory
 
         return maps
     

--- a/gdb_plus/gdb_plus.py
+++ b/gdb_plus/gdb_plus.py
@@ -2711,6 +2711,8 @@ class Debugger:
             with open(f"/proc/{self.pid}/maps") as fd:
                 maps_raw = fd.read()
             for line in maps_raw.splitlines():
+                if not context.native and "/qemu-" in line:
+                    break
                 line = line.split()
                 start, end = line[0].split("-")
                 maps[int(start, 16)] = int(end, 16) - int(start, 16)
@@ -2737,6 +2739,8 @@ class Debugger:
         for line in maps_raw.splitlines():
             if '/' not in line: continue
             path = line[line.index('/'):]
+            if not context.native and "/qemu-" in path: # Everything after the QEMU binary is only libs for QEMU that we don't want. Be careful though if this breaks something [04/02/25]
+                break
             path = os.path.realpath(path)
             if path not in maps:
                 maps[path]=0

--- a/gdb_plus/gdb_plus.py
+++ b/gdb_plus/gdb_plus.py
@@ -2732,7 +2732,7 @@ class Debugger:
             with open(f"/proc/{self.pid}/maps") as fd:
                 maps_raw = fd.read()
         except IOError:
-            maps_raw = ""
+            maps_raw = self.execute("info proc map")
 
         # Enumerate all of the libraries actually loaded right now.
         maps = {}

--- a/gdb_plus/gdb_plus.py
+++ b/gdb_plus/gdb_plus.py
@@ -2163,7 +2163,7 @@ class Debugger:
             if not self.exe.pie:
                 return address
 
-            if not address in self.exe:
+            if not address in self.exe and address < self.exe.range: # NOTE: I'm not sure yet if we should only use only allow relative breakpoints in len(exe.data) or the whole range of pages allocated to the program [05/02/25]
                 address += self.exe.address
 
         elif type(location) is str:

--- a/gdb_plus/utils.py
+++ b/gdb_plus/utils.py
@@ -220,9 +220,23 @@ class EXE(ELF):
         else:
             super().__init__(path, **kwargs)
         self.name = self.path.split("/")[-1]
-        self.address = address
+        self._address = address
         self.end_address = end_address
         self.size = len(self.data)
+
+    @property
+    def address(self):
+        return self._address
+        
+    @address.setter
+    def address(self, address):
+        if self.address != 0 and self.address != address:
+            log.warn("The base address of %s is not the one expected! Expected: %s. Received: %s", self.name, hex(self.base_libc), hex(address))
+
+        if address % 0x1000:
+            log.warn("The address %s is not a multiple of the page size 0x1000. Are you sure this is your base address ?", hex(address))
+        
+        self._address = address
 
     @property
     def range(self):

--- a/gdb_plus/utils.py
+++ b/gdb_plus/utils.py
@@ -213,22 +213,19 @@ class Breakpoint:
 # Right now it's only an ELF, but we can consider extending it to PE for windows one day
 # isinstance(obj, ELF) will accept bot EXE and ELF
 class EXE(ELF):
-    def __init__(self, path, address=0, end_address=None, **kwargs):
+    def __init__(self, path, address=None, end_address=None, **kwargs):
         if isinstance(path, ELF): 
             self.__dict__ = path.__dict__.copy()
             self.__class__ = EXE
         else:
             super().__init__(path, **kwargs)
         self.name = self.path.split("/")[-1]
-        self._address = address
+        if address is not None: # pwntools already has an assumption for the initial address
+            self.address = address
         self.end_address = end_address
         self.size = len(self.data)
-
-    @property
-    def address(self):
-        return self._address
         
-    @address.setter
+    @ELF.address.setter
     def address(self, address):
         if self.address != 0 and self.address != address:
             log.warn("The base address of %s is not the one expected! Expected: %s. Received: %s", self.name, hex(self.base_libc), hex(address))
@@ -236,8 +233,10 @@ class EXE(ELF):
         if address % 0x1000:
             log.warn("The address %s is not a multiple of the page size 0x1000. Are you sure this is your base address ?", hex(address))
         
-        self._address = address
+        ELF.address.fset(self, address)
 
+    # NOTE: What is the point of end_address = None if we set range to 0 and not None ? [05/02/25]
+    # NOTE: We could set end_address to 0, but then we would have to worry about when address is set manually, but not end_address ? Not really I would say... [05/02/25]
     @property
     def range(self):
         if self.end_address is None:

--- a/gdb_plus/utils.py
+++ b/gdb_plus/utils.py
@@ -210,6 +210,27 @@ class Breakpoint:
         self.temporary = temporary
         self.user_defined = user_defined
 
+# Right now it's only an ELF, but we can consider extending it to PE for windows one day
+# isinstance(obj, ELF) will accept bot EXE and ELF
+class EXE(ELF):
+    def __init__(self, path, address=0, end_address=None, **kwargs):
+        if isinstance(path, ELF): 
+            self.__dict__ = path.__dict__.copy()
+            self.__class__ = EXE
+        else:
+            super().__init__(path, **kwargs)
+        self.name = self.path.split("/")[-1]
+        self.address = address
+        self.end_address = end_address
+        self.size = len(self.data)
+
+    def __contains__(self, value):
+        if self.end_address is None:
+            log.warn(f"I don't know which one is the last page of {self.name}. Please set end_address!")
+            return False
+        
+        return self.address < value < self.end_address
+
 class MyLock:
     def __init__(self, event, owner):
         self.owner = owner

--- a/gdb_plus/utils.py
+++ b/gdb_plus/utils.py
@@ -223,6 +223,7 @@ class EXE(ELF):
         self.address = address
         self.end_address = end_address
         self.size = len(self.data)
+        self.range = end_address - address
 
     def __contains__(self, value):
         if self.end_address is None:

--- a/gdb_plus/utils.py
+++ b/gdb_plus/utils.py
@@ -223,7 +223,12 @@ class EXE(ELF):
         self.address = address
         self.end_address = end_address
         self.size = len(self.data)
-        self.range = end_address - address
+
+    @property
+    def range(self):
+        if self.end_address is None:
+            return 0
+        return self.end_address - self.address
 
     def __contains__(self, value):
         if self.end_address is None:

--- a/tests/test.py
+++ b/tests/test.py
@@ -153,6 +153,37 @@ class Debugger_process(unittest.TestCase):
 			self.assertEqual(data[0], 0x63)
 
 #@unittest.skip
+class Debugger_EXE(unittest.TestCase):
+	def setUp(self):
+		warnings.simplefilter("ignore", ResourceWarning)
+		warnings.simplefilter("ignore", ImportWarning)
+
+	#@unittest.skip
+	@timeout_decorator.timeout(QUICK)
+	def test_libs_qemu(self):
+		print("\ntest_libs_qemu: ", end="")
+		with context.local(binary="./risky-business"):
+			with Debugger(context.binary, aslr=False, from_entry=False) as dbg:
+				self.assertTrue(dbg.instruction_pointer not in dbg.exe)
+				self.assertTrue(dbg.instruction_pointer in dbg.ld)
+				self.assertEqual(dbg.exe.address, 0x4000000000)
+				self.assertEqual(dbg.exe.range, 0x3000)
+				self.assertEqual(dbg.ld.address, 0x4001804000)
+				self.assertEqual(dbg.ld.range, 0x23000)
+				self.assertEqual(len(dbg.libs), 2)
+				dbg.until(dbg.elf.entry)
+				self.assertEqual(len(dbg.libs), 3)
+				self.assertEqual(dbg.libc.address, 0x4001850000)
+				self.assertEqual(dbg.libc.range, 0x127000)
+				self.assertTrue(dbg.instruction_pointer in dbg.exe)
+				self.assertTrue(dbg.instruction_pointer not in dbg.libc)
+				self.assertTrue(dbg.instruction_pointer not in dbg.ld)
+				dbg.until("fgets")
+				self.assertTrue(dbg.instruction_pointer not in dbg.exe)
+				self.assertTrue(dbg.instruction_pointer in dbg.libc)
+				self.assertTrue(dbg.instruction_pointer not in dbg.ld)
+
+#@unittest.skip
 class Debugger_actions(unittest.TestCase):
 	def setUp(self):
 		warnings.simplefilter("ignore", ResourceWarning)

--- a/tests/test.py
+++ b/tests/test.py
@@ -695,7 +695,7 @@ class Debbuger_fork(unittest.TestCase):
 			flag = b""
 			for n in x:
 				flag += p32(n)
-			print(xor(flag, 0xd))
+			self.assertEqual(xor(flag, 0xd), b"CSCG{4ND_4LL_0FF_TH1S_W0RK_JU5T_T0_G3T_TH1S_STUUUP1D_FL44G??!!1}")
 
 			dbg.close()
 			child.close()
@@ -946,7 +946,7 @@ class Debugger_libdebug(unittest.TestCase):
 			self.dbg.close()
 			
 	# BROKEN !!!!!
-	@unittest.skip
+	"""@unittest.skip
 	@timeout_decorator.timeout(LONG)
 	def test_inner_debugger(self):	
 		print("\ntest_inner_debugger [libdebug]:")	
@@ -1002,6 +1002,7 @@ class Debugger_libdebug(unittest.TestCase):
 			self.assertEqual(flag, b"CSCG{4ND_4LL_0FF_TH1S_W0RK_JU5T_T0_G3T_TH1S_STUUUP1D_FL44G??!!1}")
 			self.assertFalse(self.dbg.priority)
 			self.dbg.close()
+	"""
 
 #@unittest.skip
 class Debugger_ARM(unittest.TestCase):


### PR DESCRIPTION
Extend the ELF class from pwntools to a generic EXE. The idea is to have one day an executable that can be both PE or ELF.

The additional features are:
`address in EXE` returns True if the address belongs to the pages allocated to the binary
Setting `EXE.address` will check if the address matches what gdb is expecting and if you are page aligned. The idea is to warn if the user got a wrong leak.

Bug fix:
The binary will try to reach the entry point only if we are sure to be in the loader, so we don't have the problems with the debugger attaching to a running process and calling continue by accident.

Future ideas:
We now have direct access to the loader, but it would be nice to have all the different libraries from the moment they are loaded.